### PR TITLE
Apply nonce to script tags generated via the dataScript function

### DIFF
--- a/src/TagManager.js
+++ b/src/TagManager.js
@@ -1,9 +1,13 @@
 import Snippets from './Snippets'
 
 const TagManager = {
-	dataScript: function (dataLayer) {
+	dataScript: function (dataLayer, dataLayerName, nonce) {
 		const script = document.createElement('script')
 		script.innerHTML = dataLayer
+		script.setAttribute('data-testid', dataLayerName)
+		if (nonce) {
+			script.setAttribute('nonce', nonce)
+		}
 		return script
 	},
 	gtm: function (args) {
@@ -24,7 +28,7 @@ const TagManager = {
 			return script
 		}
 
-		const dataScript = this.dataScript(snippets.dataLayerVar)
+		const dataScript = this.dataScript(snippets.dataLayerVar, args.dataLayerName, args.nonce)
 
 		return {
 			noScript,
@@ -59,7 +63,7 @@ const TagManager = {
 	dataLayer: function ({ dataLayer, dataLayerName = 'dataLayer' }) {
 		if (window[dataLayerName]) return window[dataLayerName].push(dataLayer)
 		const snippets = Snippets.dataLayer(dataLayer, dataLayerName)
-		const dataScript = this.dataScript(snippets)
+		const dataScript = this.dataScript(snippets, dataLayerName)
 		document.head.insertBefore(dataScript, document.head.childNodes[0])
 	},
 }

--- a/src/__tests__/TagManager.spec.js
+++ b/src/__tests__/TagManager.spec.js
@@ -23,6 +23,23 @@ describe('TagManager', () => {
 		}
 		TagManager.initialize(gtmArgs)
 		expect(window.dataLayer[0]).toEqual(dataLayer)
+		const dataScript = window.document.querySelector('[data-testid="dataLayer"]')
+		expect(dataScript.nonce).toBe('')
+	})
+
+	it('should render datalayer script with nonce', () => {
+		const dataLayer = {
+			userInfo: 'userInfo',
+		}
+		const gtmArgs = {
+			gtmId: 'GTM-xxxxxx',
+			dataLayer,
+			nonce: 'foo',
+		}
+		TagManager.initialize(gtmArgs)
+		expect(window.dataLayer[0]).toEqual(dataLayer)
+		const dataScript = window.document.querySelector('[data-testid="dataLayer"]')
+		expect(dataScript.nonce).toBe('foo')
 	})
 
 	it('should render nonce', () => {

--- a/src/__tests__/TagManager.spec.js
+++ b/src/__tests__/TagManager.spec.js
@@ -1,6 +1,13 @@
 import TagManager from '../TagManager'
 
 describe('TagManager', () => {
+	// Cleans the environment to ensure tests do not reference resources from previous tests (such as script tags)
+	beforeEach(() => {
+		window['dataLayer'] = undefined
+		window.document.body.innerHTML = ''
+		window.document.head.innerHTML = ''
+	})
+
 	it('should render tagmanager', () => {
 		TagManager.initialize({ gtmId: 'GTM-xxxxxx' })
 		expect(window.dataLayer).toHaveLength(1)
@@ -15,7 +22,7 @@ describe('TagManager', () => {
 			dataLayer,
 		}
 		TagManager.initialize(gtmArgs)
-		expect(window.dataLayer[1]).toEqual(dataLayer)
+		expect(window.dataLayer[0]).toEqual(dataLayer)
 	})
 
 	it('should render nonce', () => {
@@ -32,14 +39,12 @@ describe('TagManager', () => {
 	})
 
 	it('should add an event to dataLayer', () => {
-		window['dataLayer'] = undefined
 		TagManager.initialize({ gtmId: 'GTM-xxxxxx' })
 		TagManager.dataLayer({ dataLayer: { event: 'test' } })
 		expect(window['dataLayer']).toHaveLength(2)
 	})
 
 	it('should create non-existing dataLayer', () => {
-		window['dataLayer'] = undefined
 		TagManager.dataLayer({ dataLayer: { event: 'test' } })
 		expect(window['dataLayer']).not.toBeUndefined()
 		expect(window['dataLayer']).toHaveLength(1)


### PR DESCRIPTION
I noticed that if you ran a particular test individually it would fail, this is because the window and document were not being cleaned between tests, causing pollution. I fixed this in commit 69d258e748b7324219d7e22ebda28052f4c3906a.

