### PR TITLE
Removed noscript, moved warning, adjusted tests

### DIFF
--- a/src/Snippets.js
+++ b/src/Snippets.js
@@ -1,5 +1,3 @@
-import warn from './utils/warn'
-
 // https://developers.google.com/tag-manager/quickstart
 
 const Snippets = {
@@ -13,17 +11,10 @@ const Snippets = {
 		nonce = undefined,
 		source,
 	}) {
-		if (!id) warn('GTM Id is required')
-
-		const url = new URL(source)
 		const environment =
 			auth && preview
 				? `&gtm_auth=${auth}&gtm_preview=${preview}&gtm_cookies_win=x`
 				: ''
-
-		const iframe = `
-			<iframe src="${url.origin}/ns.html?id=${id}${environment}"
-				height="0" width="0" style="display:none;visibility:hidden" id="tag-manager"></iframe>`
 
 		const script = `
 			(function(w,d,s,l,i){w[l]=w[l]||[];
@@ -42,7 +33,6 @@ const Snippets = {
 		const dataLayerVar = this.dataLayer(dataLayer, dataLayerName)
 
 		return {
-			iframe,
 			script,
 			dataLayerVar,
 		}
@@ -50,7 +40,7 @@ const Snippets = {
 	dataLayer: function (dataLayer, dataLayerName) {
 		return `
 			window.${dataLayerName} = window.${dataLayerName} || [];
-			window.${dataLayerName}.push(${JSON.stringify(dataLayer)})`
+			window.${dataLayerName}.push(${JSON.stringify(dataLayer)});`
 	},
 }
 

--- a/src/TagManager.js
+++ b/src/TagManager.js
@@ -1,4 +1,5 @@
 import Snippets from './Snippets'
+import warn from './utils/warn'
 
 const TagManager = {
 	dataScript: function (dataLayer, dataLayerName, nonce) {
@@ -13,14 +14,9 @@ const TagManager = {
 	gtm: function (args) {
 		const snippets = Snippets.tags(args)
 
-		const noScript = () => {
-			const noscript = document.createElement('noscript')
-			noscript.innerHTML = snippets.iframe
-			return noscript
-		}
-
 		const script = () => {
 			const script = document.createElement('script')
+			script.setAttribute('data-testid', 'gtm')
 			script.innerHTML = snippets.script
 			if (args.nonce) {
 				script.setAttribute('nonce', args.nonce)
@@ -31,7 +27,6 @@ const TagManager = {
 		const dataScript = this.dataScript(snippets.dataLayerVar, args.dataLayerName, args.nonce)
 
 		return {
-			noScript,
 			script,
 			dataScript,
 		}
@@ -46,6 +41,10 @@ const TagManager = {
 		nonce = undefined,
 		source = 'https://googletagmanager.com/gtm.js',
 	}) {
+		if (!gtmId) {
+			warn('GTM Id is required')
+			return
+		}
 		const gtm = this.gtm({
 			id: gtmId,
 			events,
@@ -58,7 +57,6 @@ const TagManager = {
 		})
 		if (dataLayer) document.head.appendChild(gtm.dataScript)
 		document.head.insertBefore(gtm.script(), document.head.childNodes[0])
-		document.body.insertBefore(gtm.noScript(), document.body.childNodes[0])
 	},
 	dataLayer: function ({ dataLayer, dataLayerName = 'dataLayer' }) {
 		if (window[dataLayerName]) return window[dataLayerName].push(dataLayer)

--- a/src/__tests__/Snippets.spec.js
+++ b/src/__tests__/Snippets.spec.js
@@ -14,20 +14,6 @@ describe('Snippets', () => {
 		snippets = Snippets.tags(args)
 	})
 
-	it('should use the `id` for the iframe', () => {
-		expect(snippets.iframe).toContain(`id=${args.id}`, 1)
-	})
-
-	it('should use the `gtm_auth` and `gtm_preview` for the iframe', () => {
-		Object.assign(args, {
-			auth: '6sBOnZx1hqPcO01xPOytLK',
-			preview: 'env-2',
-		})
-		snippets = Snippets.tags(args)
-		expect(snippets.iframe).toContain(`gtm_auth=${args.auth}`, 1)
-		expect(snippets.iframe).toContain(`gtm_preview=${args.preview}`, 1)
-	})
-
 	it('should use the `dataLayer` for the script', () => {
 		args = { dataLayer: { name: 'test' } }
 		snippets = Snippets.dataLayer(args)
@@ -40,30 +26,11 @@ describe('Snippets', () => {
 		expect(snippets).toContain('customName')
 	})
 
-	it('no id provided should log a warn', () => {
-		console.warn = jest.fn()
-		const noIdArgs = {
-			dataLayerName: 'dataLayer',
-			events: {},
-			source: 'https://googletagmanager.com/gtm.js',
-		}
-		Snippets.tags(noIdArgs)
-		expect(console.warn).toBeCalled()
-	})
-
 	it('should use the nonce for the script', () => {
 		const nonce = 'pKFLb6zigj6vHak2TVeKx'
 		Object.assign(args, { nonce })
 		snippets = Snippets.tags(args)
 		expect(snippets.script).toContain(`setAttribute('nonce','${nonce}')`, 1)
-	})
-
-	it('should use the source URL in iframe', () => {
-		const source = 'https://tracking.example.com/gtm.js'
-		const url = new URL(source)
-		Object.assign(args, { source })
-		snippets = Snippets.tags(args)
-		expect(snippets.iframe).toContain(`src="${url.origin}/ns.html`)
 	})
 
 	it('should use the source URL in script', () => {
@@ -78,5 +45,13 @@ describe('Snippets', () => {
 		Object.assign(args, { events })
 		snippets = Snippets.tags(args)
 		expect(snippets.script).toContain(JSON.stringify(events).slice(1, -1))
+	})
+
+	it('should set up auth and preview in the script', () => {
+		const auth = 'auth'
+		const preview = 'preview'
+		Object.assign(args, { auth, preview })
+		snippets = Snippets.tags(args)
+		expect(snippets.script).toContain(`&gtm_auth=${auth}&gtm_preview=${preview}`)
 	})
 })

--- a/src/__tests__/TagManager.spec.js
+++ b/src/__tests__/TagManager.spec.js
@@ -1,4 +1,7 @@
 import TagManager from '../TagManager'
+import warn from '../utils/warn'
+
+jest.mock('../utils/warn')
 
 describe('TagManager', () => {
 	// Cleans the environment to ensure tests do not reference resources from previous tests (such as script tags)
@@ -8,12 +11,29 @@ describe('TagManager', () => {
 		window.document.head.innerHTML = ''
 	})
 
-	it('should render tagmanager', () => {
-		TagManager.initialize({ gtmId: 'GTM-xxxxxx' })
-		expect(window.dataLayer).toHaveLength(1)
+	afterEach(() => {
+		jest.clearAllMocks()
 	})
 
-	it('should render datalayer', () => {
+	it('should log a warn if no gtmId provided', () => {
+		TagManager.initialize({})
+		expect(warn).toHaveBeenCalledTimes(1)
+	})
+
+	it('should not inject tagmanager if no gtmId provided', () => {
+		TagManager.initialize({})
+		const dataScript = window.document.querySelector('[data-testid="gtm"]')
+		expect(dataScript).toBe(null)
+	})
+
+	it('should inject tagmanager', () => {
+		TagManager.initialize({ gtmId: 'GTM-xxxxxx' })
+		const gtmScript = window.document.querySelector('[data-testid="gtm"]')
+		expect(window.dataLayer).toHaveLength(1)
+		expect(gtmScript).not.toBeUndefined()
+	})
+
+	it('should create dataLayer', () => {
 		const dataLayer = {
 			userInfo: 'userInfo',
 		}
@@ -27,7 +47,7 @@ describe('TagManager', () => {
 		expect(dataScript.nonce).toBe('')
 	})
 
-	it('should render datalayer script with nonce', () => {
+	it('should create dataLayer script with nonce', () => {
 		const dataLayer = {
 			userInfo: 'userInfo',
 		}
@@ -39,13 +59,14 @@ describe('TagManager', () => {
 		TagManager.initialize(gtmArgs)
 		expect(window.dataLayer[0]).toEqual(dataLayer)
 		const dataScript = window.document.querySelector('[data-testid="dataLayer"]')
+		expect(dataScript).not.toBeUndefined()
 		expect(dataScript.nonce).toBe('foo')
 	})
 
-	it('should render nonce', () => {
+	it('should inject gtm script with nonce', () => {
 		TagManager.initialize({ gtmId: 'GTM-xxxxxx', nonce: 'foo' })
-		const scripts = window.document.getElementsByTagName('script')
-		expect(scripts[0].nonce).toBe('foo')
+		const gtmScript = window.document.querySelector('[data-testid="gtm"]')
+		expect(gtmScript.nonce).toBe('foo')
 	})
 
 	it('should use custom dataLayer name', () => {


### PR DESCRIPTION
This pull request includes several changes to the `TagManager` and `Snippets` components, focusing on code cleanup, refactoring, and updating tests. The most important changes include the removal of the iframe snippet, the addition of a warning for missing GTM ID, and the refactoring of tests to ensure proper functionality.

### Code Cleanup and Refactoring:

* [`src/Snippets.js`](diffhunk://#diff-51a25ef4ec6b68e2f6352143549ed463859155460d1641b535441406a51bbb7bL1-L2): Removed the iframe creation and the associated warning for missing GTM ID. [[1]](diffhunk://#diff-51a25ef4ec6b68e2f6352143549ed463859155460d1641b535441406a51bbb7bL1-L2) [[2]](diffhunk://#diff-51a25ef4ec6b68e2f6352143549ed463859155460d1641b535441406a51bbb7bL16-L27) [[3]](diffhunk://#diff-51a25ef4ec6b68e2f6352143549ed463859155460d1641b535441406a51bbb7bL45-R43)
* [`src/TagManager.js`](diffhunk://#diff-fbb87d621544d389367bcd227e2ebdc5ab6fbb895a3bb7da3296d9dbd1661327R2): Moved the warning for missing GTM ID to this file and added a data-testid attribute to the script element for easier testing. [[1]](diffhunk://#diff-fbb87d621544d389367bcd227e2ebdc5ab6fbb895a3bb7da3296d9dbd1661327R2) [[2]](diffhunk://#diff-fbb87d621544d389367bcd227e2ebdc5ab6fbb895a3bb7da3296d9dbd1661327L16-R19) [[3]](diffhunk://#diff-fbb87d621544d389367bcd227e2ebdc5ab6fbb895a3bb7da3296d9dbd1661327L34) [[4]](diffhunk://#diff-fbb87d621544d389367bcd227e2ebdc5ab6fbb895a3bb7da3296d9dbd1661327R44-R47) [[5]](diffhunk://#diff-fbb87d621544d389367bcd227e2ebdc5ab6fbb895a3bb7da3296d9dbd1661327L61)

### Test Updates:

* [`src/__tests__/Snippets.spec.js`](diffhunk://#diff-b691c0b7c49d54bdc93cfa2a4bf4217b431b41efb2bc83e8561576c98891ae2cL17-L30): Removed tests related to the iframe snippet and added a new test for auth and preview setup in the script. [[1]](diffhunk://#diff-b691c0b7c49d54bdc93cfa2a4bf4217b431b41efb2bc83e8561576c98891ae2cL17-L30) [[2]](diffhunk://#diff-b691c0b7c49d54bdc93cfa2a4bf4217b431b41efb2bc83e8561576c98891ae2cL43-L68) [[3]](diffhunk://#diff-b691c0b7c49d54bdc93cfa2a4bf4217b431b41efb2bc83e8561576c98891ae2cR49-R56)
* [`src/__tests__/TagManager.spec.js`](diffhunk://#diff-cbe4e2c88b3b3096125818f51ce32d280e29f53c1bbaa0ba9c7677ef2d6bddf2R2-R4): Added tests to check for the warning when GTM ID is missing and ensured that the script is not injected in such cases. Refactored existing tests to align with the changes in `TagManager.js`. [[1]](diffhunk://#diff-cbe4e2c88b3b3096125818f51ce32d280e29f53c1bbaa0ba9c7677ef2d6bddf2R2-R4) [[2]](diffhunk://#diff-cbe4e2c88b3b3096125818f51ce32d280e29f53c1bbaa0ba9c7677ef2d6bddf2L11-R36) [[3]](diffhunk://#diff-cbe4e2c88b3b3096125818f51ce32d280e29f53c1bbaa0ba9c7677ef2d6bddf2L30-R50) [[4]](diffhunk://#diff-cbe4e2c88b3b3096125818f51ce32d280e29f53c1bbaa0ba9c7677ef2d6bddf2R62-R69)